### PR TITLE
[FIX] Torture tests for phase unwrap (and small fix)

### DIFF
--- a/orangecontrib/snom/preprocess/phase_unwrap.py
+++ b/orangecontrib/snom/preprocess/phase_unwrap.py
@@ -4,12 +4,19 @@ import Orange
 import Orange.data
 from Orange.preprocess.preprocess import Preprocess
 
-from orangecontrib.spectroscopy.preprocess.utils import SelectColumn, CommonDomain
+from orangecontrib.spectroscopy.preprocess.utils import (
+    SelectColumn,
+    CommonDomainOrderUnknowns,
+)
 
 
-class _PhaseUnwrapCommon(CommonDomain):
-    def transformed(self, data):
-        return np.unwrap(data.X)
+class _PhaseUnwrapCommon(CommonDomainOrderUnknowns):
+    # A possible optimization in the future:
+    # the "order" functionality of CommonDomainOrderUnknowns is not needed,
+    # but does not break anything either
+
+    def transformed(self, X, _):  # noqa: N803
+        return np.unwrap(X)
 
 
 class PhaseUnwrap(Preprocess):

--- a/orangecontrib/snom/tests/test_preprocess.py
+++ b/orangecontrib/snom/tests/test_preprocess.py
@@ -4,10 +4,18 @@ import numpy as np
 
 from Orange.data import Table
 
+from orangecontrib.spectroscopy.tests.test_preprocess import (
+    TestCommonIndpSamplesMixin,
+    SMALLER_COLLAGEN,
+)
+
 from orangecontrib.snom.preprocess import PhaseUnwrap
 
 
-class TestPhaseUnwrap(unittest.TestCase):
+class TestPhaseUnwrap(unittest.TestCase, TestCommonIndpSamplesMixin):
+    preprocessors = [PhaseUnwrap()]
+    data = SMALLER_COLLAGEN
+
     def test_simple(self):
         data = Table.from_numpy(None, [[1, 1 + 2 * np.pi]])
         f = PhaseUnwrap()

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ setup_requires =
     setuptools-scm
 install_requires =
 	Orange3>=3.34.0
-    orange-spectroscopy>=0.6.11
+    orange-spectroscopy>=0.6.16
     numpy>=1.21.0,<2.0.0
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     # Use newer canvas-core and widget-base to avoid segfaults on windows
     oldest: orange-canvas-core==0.1.28
     oldest: orange-widget-base==4.19.0
-    oldest: orange-spectroscopy==0.6.11
+    oldest: orange-spectroscopy==0.6.16
     oldest: pandas==1.3
     oldest: numpy==1.21.0
     oldest: scikit-learn==1.0.1


### PR DESCRIPTION
Quasars/orange-spectroscopy/pull/738 allows that torture tests are also applied in other repositories.

I applied them to the only preprocessor in this repository and found a small bug. :)

This can only be merged when Quasars/orange-spectroscopy/pull/738 merged and released.