### PR TITLE
Reference input to preprocessimage

### DIFF
--- a/orangecontrib/snom/widgets/owpreprocessimage.py
+++ b/orangecontrib/snom/widgets/owpreprocessimage.py
@@ -11,7 +11,7 @@ from orangewidget.settings import SettingProvider, ContextSetting, Setting
 
 import Orange.data
 from Orange import preprocess
-from Orange.widgets.widget import Output
+from Orange.widgets.widget import Input, Output
 
 from orangecontrib.spectroscopy.widgets.owhyper import BasicImagePlot
 
@@ -67,7 +67,16 @@ class SpectralImagePreprocess(GeneralPreprocess, ImagePreviews, openclass=True):
         ImagePreviews.shutdown(self)
 
 
-class OWPreprocessImage(SpectralImagePreprocess):
+class SpectralImagePreprocessReference(SpectralImagePreprocess, openclass=True):
+    class Inputs(SpectralImagePreprocess.Inputs):
+        reference = Input("Reference", Orange.data.Table)
+
+    @Inputs.reference
+    def set_reference(self, reference):
+        self.reference_data = reference
+
+
+class OWPreprocessImage(SpectralImagePreprocessReference):
     name = "Preprocess image"
     id = "orangecontrib.snom.widgets.preprocessimage"
     description = "Process image"
@@ -279,4 +288,5 @@ class OWPreprocessImage(SpectralImagePreprocess):
 if __name__ == "__main__":  # pragma: no cover
     from Orange.widgets.utils.widgetpreview import WidgetPreview
 
-    WidgetPreview(OWPreprocessImage).run(Orange.data.Table("whitelight.gsf"))
+    data = Orange.data.Table("whitelight.gsf")
+    WidgetPreview(OWPreprocessImage).run(set_data=data, set_reference=data)

--- a/orangecontrib/snom/widgets/preprocessors/__init__.py
+++ b/orangecontrib/snom/widgets/preprocessors/__init__.py
@@ -6,3 +6,4 @@ from orangecontrib.snom.widgets.preprocessors import background_fit  # noqa: F40
 from orangecontrib.snom.widgets.preprocessors import phase_rotation  # noqa: F401
 from orangecontrib.snom.widgets.preprocessors import simple_normalize  # noqa: F401
 from orangecontrib.snom.widgets.preprocessors import linelevel  # noqa: F401
+from orangecontrib.snom.widgets.preprocessors import self_reference  # noqa: F401

--- a/orangecontrib/snom/widgets/preprocessors/self_reference.py
+++ b/orangecontrib/snom/widgets/preprocessors/self_reference.py
@@ -1,0 +1,95 @@
+# this is just an example of registration
+
+from AnyQt.QtWidgets import QFormLayout, QLabel
+
+from Orange.data import Domain
+from Orange.preprocess import Preprocess
+from orangecontrib.snom.widgets.preprocessors.registry import preprocess_image_editors
+
+from orangecontrib.spectroscopy.preprocess import SelectColumn, CommonDomain
+
+from orangecontrib.spectroscopy.widgets.preprocessors.utils import (
+    BaseEditorOrange,
+    REFERENCE_DATA_PARAM,
+)
+
+from pySNOM.images import SelfReference
+
+
+class AddFeature(SelectColumn):
+    InheritEq = True
+
+
+class _SelfRefCommon(CommonDomain):
+    def __init__(self, reference, domain):
+        super().__init__(domain)
+        self.reference = reference
+        # print(value,method)
+
+    def transformed(self, data):
+        if self.reference:
+            return SelfReference(referencedata=2 * self.reference.X).transform(data.X)
+        else:
+            return data.X
+
+
+class SelfRef(Preprocess):
+    def __init__(self, reference):
+        self.reference = reference
+
+    def __call__(self, data):
+        common = _SelfRefCommon(self.reference, data.domain)
+        atts = [
+            a.copy(compute_value=AddFeature(i, common))
+            for i, a in enumerate(data.domain.attributes)
+        ]
+        domain = Domain(atts, data.domain.class_vars, data.domain.metas)
+        return data.from_table(domain, data)
+
+
+class SelfRefEditor(BaseEditorOrange):
+    name = "Self-referencing"
+    qualname = "orangecontrib.snom.self_reference"
+
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, **kwargs)
+
+        self.reference = None
+
+        form = QFormLayout()
+        self.reference_info = QLabel("Reference data from input!")
+        form.addRow(self.reference_info)
+        self.controlArea.setLayout(form)
+
+    def activateOptions(self):
+        pass  # actions when user starts changing options
+
+    def setParameters(self, params):
+        # self.refdata = params.get("refdata", None)
+        self.update_reference_info()
+
+    @classmethod
+    def createinstance(cls, params):
+        params = dict(params)
+        reference = params.get(REFERENCE_DATA_PARAM, None)
+        return SelfRef(reference=reference)
+
+    def set_reference_data(self, reference):
+        self.reference = reference
+        self.update_reference_info()
+
+    def update_reference_info(self):
+        if not self.reference:
+            self.reference_info.setText("Reference: missing!")
+            self.reference_info.setStyleSheet("color: red")
+        else:
+            rinfo = "Reference order: N"
+            self.reference_info.setText(rinfo)
+            self.reference_info.setStyleSheet("color: black")
+
+    def set_preview_data(self, data):
+        if data:
+            pass  # TODO any settings
+
+
+preprocess_image_editors.register(SelfRefEditor, 600)


### PR DESCRIPTION
@markotoplak I know you told us not to commit changes for owpreprocessimage, but for the SelfReferencing method we need the reference input for the owprepocessimage. I went ahead and modified the widget to handle the reference input, based on how it was done in the original owpreprocess widget.

This version also contains the implemented SelfReference widget. It seems to get the reference data properly but somehow the number of points from data.X and reference.X are not the same.

`operands could not be broadcast together with shapes (5000,1) (20000,1)`