### PR TITLE
Image transformers that do not use domain transformations

### DIFF
--- a/orangecontrib/snom/preprocess/utils.py
+++ b/orangecontrib/snom/preprocess/utils.py
@@ -46,7 +46,7 @@ class PreprocessImageOpts2DOnlyWhole(PreprocessImageOpts):
                 data, (image_opts["attr_y"], image_opts["attr_x"])
             )
             image = hypercube[:, :, 0]
-            transformed = self.transform_image(image)
+            transformed = self.transform_image(image, odata)
             col = transformed[indices].reshape(-1)
         except InvalidAxisException:
             col = np.full(len(data), np.nan)
@@ -55,9 +55,10 @@ class PreprocessImageOpts2DOnlyWhole(PreprocessImageOpts):
                 data.X[:, 0] = col
         return data
 
-    def transform_image(self, image):
+    def transform_image(self, image, data):
         """
         image: a numpy 2D array where image[y,x] is the value in image row y and column x
+        data: original data set (used for passing meta data)
         """
         raise NotImplementedError
 

--- a/orangecontrib/snom/preprocess/utils.py
+++ b/orangecontrib/snom/preprocess/utils.py
@@ -43,7 +43,7 @@ class PreprocessImageOpts2DOnlyWhole(PreprocessImageOpts):
                 data.X[:, 0] = odata.get_column(image_opts["attr_value"], copy=True)
         try:
             hypercube, _, indices = get_ndim_hyperspec(
-                data, (image_opts["attr_x"], image_opts["attr_y"])
+                data, (image_opts["attr_y"], image_opts["attr_x"])
             )
             image = hypercube[:, :, 0]
             transformed = self.transform_image(image)
@@ -56,6 +56,9 @@ class PreprocessImageOpts2DOnlyWhole(PreprocessImageOpts):
         return data
 
     def transform_image(self, image):
+        """
+        image: a numpy 2D array where image[y,x] is the value in image row y and column x
+        """
         raise NotImplementedError
 
 
@@ -113,7 +116,7 @@ class CommonDomainImage2D(CommonDomain):
         data = data.transform(ndom)
         try:
             hypercube, _, indices = get_ndim_hyperspec(
-                data, (self.image_opts["attr_x"], self.image_opts["attr_y"])
+                data, (self.image_opts["attr_y"], self.image_opts["attr_x"])
             )
             image = hypercube[:, :, 0]
             transformed = self.transform_image(image)
@@ -123,4 +126,7 @@ class CommonDomainImage2D(CommonDomain):
         return self.transformed(data)
 
     def transform_image(self, image):
+        """
+        image: a numpy 2D array where image[y,x] is the value in image row y and column x
+        """
         raise NotImplementedError

--- a/orangecontrib/snom/widgets/preprocessors/background_fit.py
+++ b/orangecontrib/snom/widgets/preprocessors/background_fit.py
@@ -16,7 +16,7 @@ class BackGroundFit(PreprocessImageOpts2DOnlyWhole):
         self.xorder = xorder
         self.yorder = yorder
 
-    def transform_image(self, image):
+    def transform_image(self, image, data):
         d, b = BackgroundPolyFit(xorder=self.xorder, yorder=self.yorder).transform(
             image
         )

--- a/orangecontrib/snom/widgets/preprocessors/background_fit.py
+++ b/orangecontrib/snom/widgets/preprocessors/background_fit.py
@@ -6,15 +6,13 @@ from orangecontrib.spectroscopy.widgets.gui import lineEditIntRange
 from pySNOM.images import BackgroundPolyFit
 
 from orangecontrib.snom.preprocess.utils import (
-    PreprocessImageOpts2D,
-    CommonDomainImage2D,
+    PreprocessImageOpts2DOnlyWhole,
 )
 from orangecontrib.snom.widgets.preprocessors.registry import preprocess_image_editors
 
 
-class _BackGroundFitCommon(CommonDomainImage2D):
-    def __init__(self, xorder, yorder, domain, image_opts):
-        super().__init__(domain, image_opts)
+class BackGroundFit(PreprocessImageOpts2DOnlyWhole):
+    def __init__(self, xorder=1, yorder=1):
         self.xorder = xorder
         self.yorder = yorder
 
@@ -23,15 +21,6 @@ class _BackGroundFitCommon(CommonDomainImage2D):
             image
         )
         return d
-
-
-class BackGroundFit(PreprocessImageOpts2D):
-    def __init__(self, xorder=1, yorder=1):
-        self.xorder = xorder
-        self.yorder = yorder
-
-    def image_transformer(self, data, image_opts):
-        return _BackGroundFitCommon(self.xorder, self.yorder, data.domain, image_opts)
 
 
 class BackGroundFitEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/linelevel.py
+++ b/orangecontrib/snom/widgets/preprocessors/linelevel.py
@@ -16,7 +16,7 @@ class LineLevelProcessor(PreprocessImageOpts2DOnlyWhole):
     def __init__(self, method="median"):
         self.method = method
 
-    def transform_image(self, image):
+    def transform_image(self, image, data):
         return LineLevel(method=self.method).transform(image)
 
 

--- a/orangecontrib/snom/widgets/preprocessors/linelevel.py
+++ b/orangecontrib/snom/widgets/preprocessors/linelevel.py
@@ -8,26 +8,16 @@ from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOra
 
 from orangecontrib.snom.widgets.preprocessors.registry import preprocess_image_editors
 from orangecontrib.snom.preprocess.utils import (
-    PreprocessImageOpts2D,
-    CommonDomainImage2D,
+    PreprocessImageOpts2DOnlyWhole,
 )
 
 
-class _LineLevelCommon(CommonDomainImage2D):
-    def __init__(self, method, domain, image_opts):
-        super().__init__(domain, image_opts)
+class LineLevelProcessor(PreprocessImageOpts2DOnlyWhole):
+    def __init__(self, method="median"):
         self.method = method
 
     def transform_image(self, image):
         return LineLevel(method=self.method).transform(image)
-
-
-class LineLevelProcessor(PreprocessImageOpts2D):
-    def __init__(self, method="median"):
-        self.method = method
-
-    def image_transformer(self, data, image_opts):
-        return _LineLevelCommon(self.method, data.domain, image_opts)
 
 
 class LineLevelEditor(BaseEditorOrange):


### PR DESCRIPTION
Some image transformation methods need the whole image because they do both parameter estimation (=learning) and actual transformation (using learned parameters) in a single operation. Therefore, when transforming, instances are not independent and thus this can not be solved with domain transformation in Orange.