### PR TITLE
[ENH] Signal type attribute usage in preprocessors + fixes for linelevel combobox

### DIFF
--- a/orangecontrib/snom/widgets/preprocessors/background_fit.py
+++ b/orangecontrib/snom/widgets/preprocessors/background_fit.py
@@ -3,7 +3,7 @@ from AnyQt.QtWidgets import QFormLayout
 from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange
 from orangecontrib.spectroscopy.widgets.gui import lineEditIntRange
 
-from pySNOM.images import BackgroundPolyFit
+from pySNOM.images import BackgroundPolyFit, DataTypes
 
 from orangecontrib.snom.preprocess.utils import (
     PreprocessImageOpts2DOnlyWhole,
@@ -17,10 +17,14 @@ class BackGroundFit(PreprocessImageOpts2DOnlyWhole):
         self.yorder = yorder
 
     def transform_image(self, image, data):
-        d, b = BackgroundPolyFit(xorder=self.xorder, yorder=self.yorder).transform(
-            image
-        )
-        return d
+        if "datatype" in data.attributes:
+            datatype = data.attributes["datatype"]
+            d, b = BackgroundPolyFit(
+                xorder=self.xorder, yorder=self.yorder, datatype=DataTypes[datatype]
+            ).transform(image)
+            return d
+        else:
+            return image
 
 
 class BackGroundFitEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/background_fit.py
+++ b/orangecontrib/snom/widgets/preprocessors/background_fit.py
@@ -17,14 +17,11 @@ class BackGroundFit(PreprocessImageOpts2DOnlyWhole):
         self.yorder = yorder
 
     def transform_image(self, image, data):
-        if "datatype" in data.attributes:
-            datatype = data.attributes["datatype"]
-            d, b = BackgroundPolyFit(
-                xorder=self.xorder, yorder=self.yorder, datatype=DataTypes[datatype]
-            ).transform(image)
-            return d
-        else:
-            return image
+        datatype = data.attributes.get("measurement.signaltype", "Phase")
+        d, b = BackgroundPolyFit(
+            xorder=self.xorder, yorder=self.yorder, datatype=DataTypes[datatype]
+        ).transform(image)
+        return d
 
 
 class BackGroundFitEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/linelevel.py
+++ b/orangecontrib/snom/widgets/preprocessors/linelevel.py
@@ -2,7 +2,7 @@ from AnyQt.QtWidgets import QFormLayout
 
 from orangewidget.gui import comboBox
 
-from pySNOM.images import LineLevel
+from pySNOM.images import LineLevel, DataTypes
 
 from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange
 
@@ -17,7 +17,13 @@ class LineLevelProcessor(PreprocessImageOpts2DOnlyWhole):
         self.method = method
 
     def transform_image(self, image, data):
-        return LineLevel(method=self.method).transform(image)
+        if "datatype" in data.attributes:
+            datatype = data.attributes["datatype"]
+            return LineLevel(
+                method=self.method, datatype=DataTypes[datatype]
+            ).transform(image)
+        else:
+            return LineLevel(method=self.method).transform(image)
 
 
 class LineLevelEditor(BaseEditorOrange):
@@ -30,22 +36,26 @@ class LineLevelEditor(BaseEditorOrange):
         self.method = 'median'
 
         form = QFormLayout()
-        levelmethod = comboBox(self, self, "method", callback=self.edited.emit)
-        levelmethod.addItems(['median', 'mean', 'difference'])
-        form.addRow("Leveling method", levelmethod)
+        self.levelmethod_cb = comboBox(self, self, "method", callback=self.setmethod)
+        self.levelmethod_cb.addItems(['median', 'mean', 'difference'])
+        form.addRow("Leveling method", self.levelmethod_cb)
         self.controlArea.setLayout(form)
 
     def activateOptions(self):
         pass  # actions when user starts changing options
 
+    def setmethod(self):
+        self.method = self.levelmethod_cb.currentText()
+        self.edited.emit()
+
     def setParameters(self, params):
-        self.levelmethod = params.get("levelmethod", "median")
+        self.method = params.get("method", "median")
 
     @classmethod
     def createinstance(cls, params):
         params = dict(params)
-        levelmethod = params.get("levelmethod", "median")
-        return LineLevelProcessor(method=levelmethod)
+        method = params.get("method", "median")
+        return LineLevelProcessor(method=method)
 
     def set_preview_data(self, data):
         if data:

--- a/orangecontrib/snom/widgets/preprocessors/linelevel.py
+++ b/orangecontrib/snom/widgets/preprocessors/linelevel.py
@@ -17,13 +17,10 @@ class LineLevelProcessor(PreprocessImageOpts2DOnlyWhole):
         self.method = method
 
     def transform_image(self, image, data):
-        if "datatype" in data.attributes:
-            datatype = data.attributes["datatype"]
-            return LineLevel(
-                method=self.method, datatype=DataTypes[datatype]
-            ).transform(image)
-        else:
-            return LineLevel(method=self.method).transform(image)
+        datatype = data.attributes.get("measurement.signaltype", "Phase")
+        return LineLevel(
+            method=self.method, datatype=DataTypes[datatype]
+        ).transform(image)
 
 
 class LineLevelEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/linelevel.py
+++ b/orangecontrib/snom/widgets/preprocessors/linelevel.py
@@ -18,9 +18,9 @@ class LineLevelProcessor(PreprocessImageOpts2DOnlyWhole):
 
     def transform_image(self, image, data):
         datatype = data.attributes.get("measurement.signaltype", "Phase")
-        return LineLevel(
-            method=self.method, datatype=DataTypes[datatype]
-        ).transform(image)
+        return LineLevel(method=self.method, datatype=DataTypes[datatype]).transform(
+            image
+        )
 
 
 class LineLevelEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/self_reference.py
+++ b/orangecontrib/snom/widgets/preprocessors/self_reference.py
@@ -21,13 +21,10 @@ class SelfRef(PreprocessImageOpts2DOnlyWholeReference):
             raise MissingReferenceException("Self-referencing needs a reference")
 
     def transform_image(self, image, ref_image, data):
-        if "datatype" in data.attributes:
-            datatype = data.attributes["datatype"]
-            return SelfReference(
-                referencedata=ref_image, datatype=DataTypes[datatype]
-            ).transform(image)
-        else:
-            return SelfReference(referencedata=ref_image).transform(image)
+        datatype = data.attributes.get("measurement.signaltype", "Phase")
+        return SelfReference(
+            referencedata=ref_image, datatype=DataTypes[datatype]
+        ).transform(image)
 
 
 class SelfRefEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/self_reference.py
+++ b/orangecontrib/snom/widgets/preprocessors/self_reference.py
@@ -6,7 +6,7 @@ from orangecontrib.spectroscopy.widgets.preprocessors.utils import (
     REFERENCE_DATA_PARAM,
 )
 
-from pySNOM.images import SelfReference
+from pySNOM.images import SelfReference, DataTypes
 
 from orangecontrib.snom.preprocess.utils import (
     PreprocessImageOpts2DOnlyWholeReference,
@@ -21,8 +21,13 @@ class SelfRef(PreprocessImageOpts2DOnlyWholeReference):
             raise MissingReferenceException("Self-referencing needs a reference")
 
     def transform_image(self, image, ref_image, data):
-        d = SelfReference(referencedata=ref_image).transform(image)
-        return d
+        if "datatype" in data.attributes:
+            datatype = data.attributes["datatype"]
+            return SelfReference(
+                referencedata=ref_image, datatype=DataTypes[datatype]
+            ).transform(image)
+        else:
+            return SelfReference(referencedata=ref_image).transform(image)
 
 
 class SelfRefEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/simple_normalize.py
+++ b/orangecontrib/snom/widgets/preprocessors/simple_normalize.py
@@ -18,15 +18,10 @@ class SimpleNorm(PreprocessImageOpts2DOnlyWhole):
         self.value = value
 
     def transform_image(self, image, data):
-        if "datatype" in data.attributes:
-            datatype = data.attributes["datatype"]
-            return SimpleNormalize(
-                method=self.method, value=self.value, datatype=DataTypes[datatype]
-            ).transform(image)
-        else:
-            return SimpleNormalize(method=self.method, value=self.value).transform(
-                image
-            )
+        datatype = data.attributes.get("measurement.signaltype", "Phase")
+        return SimpleNormalize(
+            method=self.method, value=self.value, datatype=DataTypes[datatype]
+        ).transform(image)
 
 
 class SimpleNormEditor(BaseEditorOrange):

--- a/orangecontrib/snom/widgets/preprocessors/simple_normalize.py
+++ b/orangecontrib/snom/widgets/preprocessors/simple_normalize.py
@@ -1,46 +1,32 @@
 from AnyQt.QtWidgets import QFormLayout
 
-from Orange.data import Domain
-from Orange.preprocess import Preprocess
-from orangecontrib.snom.widgets.preprocessors.registry import preprocess_image_editors
-
-from orangecontrib.spectroscopy.preprocess import SelectColumn, CommonDomain
-
 from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange
 from orangecontrib.spectroscopy.widgets.gui import lineEditFloatRange
 from orangewidget.gui import comboBox
 
-from pySNOM.images import SimpleNormalize
+from pySNOM.images import SimpleNormalize, DataTypes
+
+from orangecontrib.snom.widgets.preprocessors.registry import preprocess_image_editors
+from orangecontrib.snom.preprocess.utils import (
+    PreprocessImageOpts2DOnlyWhole,
+)
 
 
-class AddFeature(SelectColumn):
-    InheritEq = True
-
-
-class _SimpleNormCommon(CommonDomain):
-    def __init__(self, method, value, domain):
-        super().__init__(domain)
-        self.method = method
-        self.value = value
-        # print(value,method)
-
-    def transformed(self, data):
-        return SimpleNormalize(method=self.method, value=self.value).transform(data.X)
-
-
-class SimpleNorm(Preprocess):
-    def __init__(self, method='median', value=1.0):
+class SimpleNorm(PreprocessImageOpts2DOnlyWhole):
+    def __init__(self, method, value):
         self.method = method
         self.value = value
 
-    def __call__(self, data):
-        common = _SimpleNormCommon(self.method, self.value, data.domain)
-        atts = [
-            a.copy(compute_value=AddFeature(i, common))
-            for i, a in enumerate(data.domain.attributes)
-        ]
-        domain = Domain(atts, data.domain.class_vars, data.domain.metas)
-        return data.from_table(domain, data)
+    def transform_image(self, image, data):
+        if "datatype" in data.attributes:
+            datatype = data.attributes["datatype"]
+            return SimpleNormalize(
+                method=self.method, value=self.value, datatype=DataTypes[datatype]
+            ).transform(image)
+        else:
+            return SimpleNormalize(method=self.method, value=self.value).transform(
+                image
+            )
 
 
 class SimpleNormEditor(BaseEditorOrange):


### PR DESCRIPTION
@markotoplak @borondics 
I updated all the preprocessors that require the datatype attribute and changed `simple_normalize` to use image data. I also added fixes for the `linelevel` because the current value of the combo box was not properly read.

Everything seems to work correctly as I checked with orange-canvas.