### PR TITLE
Preprocess image: sync attributes in imageplots on new data

### DIFF
--- a/orangecontrib/snom/widgets/owpreprocessimage.py
+++ b/orangecontrib/snom/widgets/owpreprocessimage.py
@@ -317,7 +317,7 @@ class OWPreprocessImage(SpectralImagePreprocessReference):
             # to generate valid interface even if context was not loaded
             self.contextAboutToBeOpened.emit([data])
 
-        self.redraw_data()
+        self.update_attr()  # update imageplots attributes from the master
 
     @staticmethod
     def run_task(


### PR DESCRIPTION
Hopefully fixes #25

I did not manage to reproduce the issue (well, I think would need a dataset with additional meta column for that). :)

But I did fix one issue that was surely in: after a new data was set, the imageplot axes values were not synchronized with the main interface.