### PR TITLE
Masking

### DIFF
--- a/orangecontrib/snom/preprocess/utils.py
+++ b/orangecontrib/snom/preprocess/utils.py
@@ -14,10 +14,7 @@ from orangecontrib.spectroscopy.utils import (
     values_to_linspace,
     index_values,
 )
-from orangecontrib.spectroscopy.widgets.utils import (
-    groups_or_annotated_table,
-    create_groups_table,
-)
+
 from pySNOM.images import mask_from_datacondition
 
 class PreprocessImageOpts(Preprocess):
@@ -200,13 +197,15 @@ class SelectionMaskImageOpts2DMixin:
     def get_mask(self, data, mask_attr_value = None, value=1.0):
 
         self.selected_image_opts["attr_value"] = mask_attr_value
-
-        try:
-            #Prepare a mask compatible with pySNOM tranformers
-            masktable = _prepare_table_for_image(data, self.selected_image_opts)
-            maskimage, _ = _image_from_table(masktable, self.selected_image_opts)
-            mask = mask_from_datacondition(maskimage==value)
-        except KeyError:
+        if self.data is not None:
+            try:
+                #Prepare a mask compatible with pySNOM tranformers
+                masktable = _prepare_table_for_image(data, self.selected_image_opts)
+                maskimage, _ = _image_from_table(masktable, self.selected_image_opts)
+                mask = mask_from_datacondition(maskimage==value)
+            except KeyError:
+                mask = None
+        else:
             mask = None
         
         return mask

--- a/orangecontrib/snom/preprocess/utils.py
+++ b/orangecontrib/snom/preprocess/utils.py
@@ -17,6 +17,7 @@ from orangecontrib.spectroscopy.utils import (
 
 from pySNOM.images import mask_from_datacondition
 
+
 class PreprocessImageOpts(Preprocess):
     pass
 
@@ -181,12 +182,11 @@ class CommonDomainImage2D(CommonDomain):
 
 
 class SelectionMaskImageOpts2DMixin:
-
     selected_image_opts = {
-            'attr_x': str("map_x"),
-            'attr_y': str("map_y"),
-            'attr_value': "Selected",
-        }
+        'attr_x': "map_x",
+        'attr_y': "map_y",
+        'attr_value': "Selected",
+    }
 
     class Warning(OWWidget.Warning):
         no_mask_group = Msg("Compatibility mode: Selection does not output Groups.")
@@ -194,18 +194,17 @@ class SelectionMaskImageOpts2DMixin:
     def __init__(self):
         pass
 
-    def get_mask(self, data, mask_attr_value = None, value=1.0):
-
+    def get_mask(self, data, mask_attr_value=None, value=1.0):
         self.selected_image_opts["attr_value"] = mask_attr_value
         if self.data is not None:
             try:
-                #Prepare a mask compatible with pySNOM tranformers
+                # Prepare a mask compatible with pySNOM tranformers
                 masktable = _prepare_table_for_image(data, self.selected_image_opts)
                 maskimage, _ = _image_from_table(masktable, self.selected_image_opts)
-                mask = mask_from_datacondition(maskimage==value)
+                mask = mask_from_datacondition(maskimage == value)
             except KeyError:
                 mask = None
         else:
             mask = None
-        
+
         return mask

--- a/orangecontrib/snom/preprocess/utils.py
+++ b/orangecontrib/snom/preprocess/utils.py
@@ -62,7 +62,7 @@ def _image_from_table(data, image_opts):
 
 
 class PreprocessImageOpts2DOnlyWhole(PreprocessImageOpts):
-    def __call__(self, data, image_opts,mask=None):
+    def __call__(self, data, image_opts, mask=None):
         data = _prepare_table_for_image(data, image_opts)
         try:
             image, indices = _image_from_table(data, image_opts)
@@ -84,7 +84,7 @@ class PreprocessImageOpts2DOnlyWhole(PreprocessImageOpts):
 
 
 class PreprocessImageOpts2DOnlyWholeReference(PreprocessImageOpts):
-    def __call__(self, data, image_opts):
+    def __call__(self, data, image_opts, mask=None):
         data = _prepare_table_for_image(data, image_opts)
         reference = _prepare_table_for_image(self.reference, image_opts)
         try:

--- a/orangecontrib/snom/widgets/owpreprocessimage.py
+++ b/orangecontrib/snom/widgets/owpreprocessimage.py
@@ -6,7 +6,10 @@ from Orange.data import Domain, DiscreteVariable, ContinuousVariable
 from Orange.widgets.settings import DomainContextHandler
 from Orange.widgets.utils.itemmodels import DomainModel
 from orangecontrib.snom.widgets.preprocessors.registry import preprocess_image_editors
-from orangecontrib.snom.preprocess.utils import PreprocessImageOpts, SelectionMaskImageOpts2DMixin
+from orangecontrib.snom.preprocess.utils import (
+    PreprocessImageOpts,
+    SelectionMaskImageOpts2DMixin,
+)
 from orangewidget import gui
 from orangewidget.settings import SettingProvider, ContextSetting, Setting
 
@@ -68,6 +71,7 @@ class SpectralImagePreprocess(GeneralPreprocess, ImagePreviews, openclass=True):
         super().onDeleteWidget()
         ImagePreviews.shutdown(self)
 
+
 def execute_with_image_opts(pp, data, image_opts, mask=None):
     if isinstance(pp, PreprocessImageOpts):
         return pp(data, image_opts, mask)
@@ -99,7 +103,7 @@ class ImagePreviewRunner(PreviewRunner):
                 pp_def,
                 master.process_reference,
             )
-            
+
         else:
             master.curveplot.set_data(None)
             master.curveplot_after.set_data(None)
@@ -143,7 +147,9 @@ class SpectralImagePreprocessReference(SpectralImagePreprocess, openclass=True):
         self.reference_data = reference
 
 
-class OWPreprocessImage(SpectralImagePreprocessReference, SelectionMaskImageOpts2DMixin):
+class OWPreprocessImage(
+    SpectralImagePreprocessReference, SelectionMaskImageOpts2DMixin
+):
     name = "Preprocess image"
     id = "orangecontrib.snom.widgets.preprocessimage"
     description = "Process image"
@@ -202,18 +208,28 @@ class OWPreprocessImage(SpectralImagePreprocessReference, SelectionMaskImageOpts
                 DomainModel.CLASSES,
                 DomainModel.Separator,
                 DomainModel.METAS,
-                ),
-                valid_types=DiscreteVariable,)
-        
+            ),
+            valid_types=DiscreteVariable,
+        )
+
         self.cb_mask_var = gui.comboBox(
-            mbox, self, "mask_attr_value",
-            contentsLength=12, searchable=True,
-            callback=self.update_mask_value_items, model=self.mask_value_model)
-        
+            mbox,
+            self,
+            "mask_attr_value",
+            contentsLength=12,
+            searchable=True,
+            callback=self.update_mask_value_items,
+            model=self.mask_value_model,
+        )
+
         self.cb_mask_value = gui.comboBox(
-            mbox, self, "mask_group_value",
-            contentsLength=12, callback=self.set_mask_from_selection)
-        
+            mbox,
+            self,
+            "mask_group_value",
+            contentsLength=12,
+            callback=self.set_mask_from_selection,
+        )
+
         self.feature_value_model = DomainModel(
             order=(
                 DomainModel.ATTRIBUTES,
@@ -310,7 +326,9 @@ class OWPreprocessImage(SpectralImagePreprocessReference, SelectionMaskImageOpts
     def update_mask_value_items(self):
         self.cb_mask_value.clear()
         try:
-            self.cb_mask_value.addItems(list(self.data.domain[self.mask_attr_value].values))
+            self.cb_mask_value.addItems(
+                list(self.data.domain[self.mask_attr_value].values)
+            )
             self.cb_mask_value.setCurrentIndex(0)
             self.mask_group_value = 0
             # Need to update manually
@@ -319,7 +337,9 @@ class OWPreprocessImage(SpectralImagePreprocessReference, SelectionMaskImageOpts
             pass
 
     def set_mask_from_selection(self):
-        self.mask_table = self.get_mask(self.data,mask_attr_value=self.mask_attr_value,value=self.mask_group_value)
+        self.mask_table = self.get_mask(
+            self.data, mask_attr_value=self.mask_attr_value, value=self.mask_group_value
+        )
         self.on_modelchanged()
 
     def image_opts(self):

--- a/orangecontrib/snom/widgets/preprocessors/background_fit.py
+++ b/orangecontrib/snom/widgets/preprocessors/background_fit.py
@@ -2,8 +2,9 @@ from AnyQt.QtWidgets import QFormLayout
 
 from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange
 from orangecontrib.spectroscopy.widgets.gui import lineEditIntRange
+from orangewidget.gui import checkBox
 
-from pySNOM.images import BackgroundPolyFit, DataTypes
+from pySNOM.images import MaskedBackgroundPolyFit, DataTypes
 
 from orangecontrib.snom.preprocess.utils import (
     PreprocessImageOpts2DOnlyWhole,
@@ -12,15 +13,17 @@ from orangecontrib.snom.widgets.preprocessors.registry import preprocess_image_e
 
 
 class BackGroundFit(PreprocessImageOpts2DOnlyWhole):
-    def __init__(self, xorder=1, yorder=1):
+    def __init__(self, xorder=1, yorder=1, use_mask=False):
         self.xorder = xorder
         self.yorder = yorder
+        self.use_mask = use_mask
 
-    def transform_image(self, image, data):
+    def transform_image(self, image, data, mask=None):
         datatype = data.attributes.get("measurement.signaltype", "Phase")
-        d, b = BackgroundPolyFit(
+        mask = mask if self.use_mask else None
+        d = MaskedBackgroundPolyFit(
             xorder=self.xorder, yorder=self.yorder, datatype=DataTypes[datatype]
-        ).transform(image)
+        ).transform(image,mask=mask)
         return d
 
 
@@ -33,12 +36,17 @@ class BackGroundFitEditor(BaseEditorOrange):
 
         self.xorder = 1
         self.yorder = 1
+        self.use_mask = False
 
         form = QFormLayout()
         xorderedit = lineEditIntRange(self, self, "xorder", callback=self.edited.emit)
         yorderedit = lineEditIntRange(self, self, "yorder", callback=self.edited.emit)
+        self.use_mask_chb = checkBox(self, self,"use_mask","Enable",callback=self.edited.emit)
+        
         form.addRow("xorder", xorderedit)
         form.addRow("yorder", yorderedit)
+        form.addRow("Masking", self.use_mask_chb)
+
         self.controlArea.setLayout(form)
 
     def activateOptions(self):
@@ -47,13 +55,15 @@ class BackGroundFitEditor(BaseEditorOrange):
     def setParameters(self, params):
         self.xorder = params.get("xorder", 1)
         self.yorder = params.get("yorder", 1)
+        self.use_mask = params.get("use_mask", False)
 
     @classmethod
     def createinstance(cls, params):
         params = dict(params)
         xorder = float(params.get("xorder", 1))
         yorder = float(params.get("yorder", 1))
-        return BackGroundFit(xorder=xorder, yorder=yorder)
+        use_mask = bool(params.get("use_mask", False))
+        return BackGroundFit(xorder=xorder, yorder=yorder, use_mask=use_mask)
 
     def set_preview_data(self, data):
         if data:

--- a/orangecontrib/snom/widgets/preprocessors/background_fit.py
+++ b/orangecontrib/snom/widgets/preprocessors/background_fit.py
@@ -23,7 +23,7 @@ class BackGroundFit(PreprocessImageOpts2DOnlyWhole):
         mask = mask if self.use_mask else None
         d = MaskedBackgroundPolyFit(
             xorder=self.xorder, yorder=self.yorder, datatype=DataTypes[datatype]
-        ).transform(image,mask=mask)
+        ).transform(image, mask=mask)
         return d
 
 
@@ -41,8 +41,10 @@ class BackGroundFitEditor(BaseEditorOrange):
         form = QFormLayout()
         xorderedit = lineEditIntRange(self, self, "xorder", callback=self.edited.emit)
         yorderedit = lineEditIntRange(self, self, "yorder", callback=self.edited.emit)
-        self.use_mask_chb = checkBox(self, self,"use_mask","Enable",callback=self.edited.emit)
-        
+        self.use_mask_chb = checkBox(
+            self, self, "use_mask", "Enable", callback=self.edited.emit
+        )
+
         form.addRow("xorder", xorderedit)
         form.addRow("yorder", yorderedit)
         form.addRow("Masking", self.use_mask_chb)

--- a/orangecontrib/snom/widgets/preprocessors/linelevel.py
+++ b/orangecontrib/snom/widgets/preprocessors/linelevel.py
@@ -23,7 +23,7 @@ class LineLevelProcessor(PreprocessImageOpts2DOnlyWhole):
         mask = mask if self.use_mask else None
         processed = LineLevel(
             method=self.method, datatype=DataTypes[datatype]
-        ).transform(image,mask=mask)
+        ).transform(image, mask=mask)
         if self.method == 'difference':
             # add a row of NaN, so that the size matches
             processed = np.vstack((processed, np.full((1, image.shape[1]), np.nan)))
@@ -45,7 +45,9 @@ class LineLevelEditor(BaseEditorOrange):
         self.levelmethod_cb.addItems(['median', 'mean', 'difference'])
         form.addRow("Leveling method", self.levelmethod_cb)
 
-        self.use_mask_chb = checkBox(self, self,"use_mask","Enable",callback=self.edited.emit)
+        self.use_mask_chb = checkBox(
+            self, self, "use_mask", "Enable", callback=self.edited.emit
+        )
         form.addRow("Masking", self.use_mask_chb)
         self.controlArea.setLayout(form)
 
@@ -65,7 +67,7 @@ class LineLevelEditor(BaseEditorOrange):
         params = dict(params)
         method = params.get("method", "median")
         use_mask = bool(params.get("use_mask", False))
-        return LineLevelProcessor(method=method,use_mask=use_mask)
+        return LineLevelProcessor(method=method, use_mask=use_mask)
 
     def set_preview_data(self, data):
         if data:

--- a/orangecontrib/snom/widgets/preprocessors/linelevel.py
+++ b/orangecontrib/snom/widgets/preprocessors/linelevel.py
@@ -17,11 +17,11 @@ class LineLevelProcessor(PreprocessImageOpts2DOnlyWhole):
     def __init__(self, method="median"):
         self.method = method
 
-    def transform_image(self, image, data):
+    def transform_image(self, image, data, mask=None):
         datatype = data.attributes.get("measurement.signaltype", "Phase")
         processed = LineLevel(
             method=self.method, datatype=DataTypes[datatype]
-        ).transform(image)
+        ).transform(image,mask=mask)
         if self.method == 'difference':
             # add a row of NaN, so that the size matches
             processed = np.vstack((processed, np.full((1, image.shape[1]), np.nan)))

--- a/orangecontrib/snom/widgets/preprocessors/simple_normalize.py
+++ b/orangecontrib/snom/widgets/preprocessors/simple_normalize.py
@@ -44,7 +44,9 @@ class SimpleNormEditor(BaseEditorOrange):
         self.cb_method = comboBox(self, self, "method", callback=self.setmethod)
         self.cb_method.addItems(['median', 'mean', 'manual'])
         self.cb_method.setCurrentText('manual')
-        self.use_mask_chb = checkBox(self, self,"use_mask","Enable",callback=self.edited.emit)
+        self.use_mask_chb = checkBox(
+            self, self, "use_mask", "Enable", callback=self.edited.emit
+        )
 
         form.addRow("Method", self.cb_method)
         form.addRow("Value", self.valueedit)


### PR DESCRIPTION
We rediscussed with @borondics the way of using masks in OWPreprocessImage.
The conclusion was that probably the most flexible way is to use the categories of meta and class variables so the user could use any selection, cluster, etc, to define the mask.

This PR implements a 'Mask selection' box where the user can select the desired group. The synthesized mask is passed to the preprocessor, which is updated now through pySNOM.

Preprocess editors are also updated to enable or disable the use of the mask.

I tried to do it with the least amount of modifications.